### PR TITLE
Add "types" to "exports" section in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "types": "dist/index.d.ts",
   "exports": {
     "require": "./dist/index.common.js",
-    "import": "./dist/index.esm.js"
+    "import": "./dist/index.esm.js",
+    "types": "./dist/types/index.d.ts"
   },
   "scripts": {
     "build": "npm run build:cjs && npm run build:umd && npm run build:esm",


### PR DESCRIPTION
This changes fix issue with import in projects with Typescript 5+ versions with moduleResolution: bundler option