### PR TITLE
Disable onClick for getRootProps

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,24 +38,24 @@
     "vue": ">=3"
   },
   "devDependencies": {
-    "@testing-library/jest-dom": "^5.11.9",
-    "@testing-library/vue": "^6.3.1",
-    "@types/jest": "^26.0.20",
-    "@types/testing-library__jest-dom": "^5.9.5",
-    "babel-jest": "^26.6.3",
-    "jest": "^26.6.3",
-    "jest-serializer-vue": "^2.0.2",
-    "jest-watch-typeahead": "^0.6.1",
-    "rollup": "^4.7.0",
+    "@testing-library/jest-dom": "^6.5.0",
+    "@testing-library/vue": "^8.1.0",
+    "@types/jest": "^29.5.12",
+    "@types/testing-library__jest-dom": "^6.0.0",
+    "babel-jest": "^29.7.0",
+    "jest": "^29.7.0",
+    "jest-serializer-vue": "^3.1.0",
+    "jest-watch-typeahead": "^2.2.2",
+    "rollup": "^4.21.2",
     "rollup-plugin-typescript2": "^0.36.0",
-    "ts-jest": "^26.5.2",
-    "tslib": "^2.6.2",
-    "typescript": "^5.3.3",
-    "vue": "^3.0.4"
+    "ts-jest": "^29.2.5",
+    "tslib": "^2.7.0",
+    "typescript": "^5.5.4",
+    "vue": "^3.5.0"
   },
   "dependencies": {
     "attr-accept": "^2.2.2",
-    "file-selector": "^0.2.4"
+    "file-selector": "^0.6.0"
   },
   "files": [
     "dist"

--- a/src/useDropzone.ts
+++ b/src/useDropzone.ts
@@ -490,7 +490,6 @@ export function useDropzone(options: Partial<FileUploadOptions> = {}) {
   const getRootProps = ({
     onFocus,
     onBlur,
-    onClick,
     onDragEnter,
     onDragenter,
     onDragOver,
@@ -504,7 +503,6 @@ export function useDropzone(options: Partial<FileUploadOptions> = {}) {
   } = {}) => ({
     onFocus: composeKeyboardHandler(composeEventHandlers(onFocus, onFocusCb)),
     onBlur: composeKeyboardHandler(composeEventHandlers(onBlur, onBlurCb)),
-    onClick: composeHandler(composeEventHandlers(onClick, onClickCb)),
     onDragenter: composeDragHandler(composeEventHandlers(onDragEnter, onDragenter, onDragEnterCb)),
     onDragover: composeDragHandler(composeEventHandlers(onDragOver, onDragover, onDragOverCb)),
     onDragleave: composeDragHandler(composeEventHandlers(onDragLeave, onDragleave, onDragLeaveCb)),


### PR DESCRIPTION
This PR removes `onClick` handler from `getRootProps`.
This allows to have a click event with `getInputProps` on a particular element (button) and use wider area for `getRootProps` to enable dropzone.